### PR TITLE
Enable Action

### DIFF
--- a/.github/workflows/dotnet_build.yml
+++ b/.github/workflows/dotnet_build.yml
@@ -1,0 +1,63 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build_linux:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.204
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Publish
+      run: dotnet publish -c Release -p:PublishProfile=./SCHALE.GameServer/Properties/PublishProfiles/linux_x64.pubxml
+    - name: rm files
+      run: |
+        rm -rf ./SCHALE.GameServer/bin/Release/net8.0/linux-x64/publish/SCHALE.GameServer.pdb
+        rm -rf ./SCHALE.GameServer/bin/Release/net8.0/linux-x64/publish/SCHALE.Common.pdb
+        rm -rf ./SCHALE.GameServer/bin/Release/net8.0/linux-x64/publish/appsettings.Docker.json
+        rm -rf ./SCHALE.GameServer/bin/Release/net8.0/linux-x64/publish/appsettings.Development.json
+    - name: Upload output
+      uses: actions/upload-artifact@v2
+      with:
+        name: "Build_Linux"
+        path: ./SCHALE.GameServer/bin/Release/net8.0/linux-x64/publish
+
+  build_win:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.204
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Publish
+      run: dotnet publish -c Release -p:PublishProfile=./SCHALE.GameServer/Properties/PublishProfiles/win_x64.pubxml
+    - name: rm files
+      run: |
+        del ./SCHALE.GameServer/bin/Release/net8.0/win-x64/publish/SCHALE.GameServer.pdb
+        del ./SCHALE.GameServer/bin/Release/net8.0/win-x64/publish/SCHALE.Common.pdb
+        del ./SCHALE.GameServer/bin/Release/net8.0/win-x64/publish/appsettings.Docker.json
+        del ./SCHALE.GameServer/bin/Release/net8.0/win-x64/publish/appsettings.Development.json
+    - name: Upload output
+      uses: actions/upload-artifact@v2
+      with:
+        name: "Build_Windows"
+        path: ./SCHALE.GameServer/bin/Release/net8.0/win-x64/publish

--- a/.gitignore
+++ b/.gitignore
@@ -184,7 +184,7 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+# *.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/SCHALE.GameServer/Properties/PublishProfiles/linux_x64.pubxml
+++ b/SCHALE.GameServer/Properties/PublishProfiles/linux_x64.pubxml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>false</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\Release\net8.0\publish\linux_x64</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+    <SiteUrlToLaunchAfterPublish />
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <ProjectGuid>fa808fe1-3f81-4afc-9fbe-8662b9781ef8</ProjectGuid>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/SCHALE.GameServer/Properties/PublishProfiles/win_x64.pubxml
+++ b/SCHALE.GameServer/Properties/PublishProfiles/win_x64.pubxml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>false</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\Release\net8.0\publish\win_x64</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+    <SiteUrlToLaunchAfterPublish />
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <ProjectGuid>fa808fe1-3f81-4afc-9fbe-8662b9781ef8</ProjectGuid>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
. pubXML has been cancelled in. gitignore
Binary files for both Windows and Linux platforms are built in Action
More than 100 MB is because the deployment mode is independent and does not require installation NET Framework Ready to Use