### PR TITLE
Remove retry behavior of SQL Server DbContext backend

### DIFF
--- a/SCHALE.GameServer/Utils/ServiceExtensions.cs
+++ b/SCHALE.GameServer/Utils/ServiceExtensions.cs
@@ -22,12 +22,8 @@ namespace SCHALE.GameServer.Utils
                 case "SQLServer":
                     services.AddDbContext<SCHALEContext>(opt =>
                        opt
-                       .UseSqlServer(conf.GetConnectionString("SQLServer") ?? throw NoConnectionStringException,
-                        actions =>
-                        {
-                            actions.EnableRetryOnFailure(5, TimeSpan.FromSeconds(10), null);
-                        })
-                        .UseLazyLoadingProxies()
+                       .UseSqlServer(conf.GetConnectionString("SQLServer") ?? throw NoConnectionStringException)
+                       .UseLazyLoadingProxies()
                     , ServiceLifetime.Singleton, ServiceLifetime.Singleton);
                     break;
                 default: throw new ArgumentException($"SQL Provider '{sqlProvider}' is not valid");


### PR DESCRIPTION
According to [MSDN](https://learn.microsoft.com/en-us/ef/ef6/fundamentals/connection-resiliency/retry-logic), `SqlServerRetryingExecutionStrategy` will automatically create transactions for database updates, however:

1. Not all db updates need to be rollbacked if failed. Remove automatic retry will avoid unnecessary transactions.
2. `SqlServerRetryingExecutionStrategy` is a SQL Server specific class, thus making it not portable to other backends.
